### PR TITLE
Fix case insensitive win condition

### DIFF
--- a/src/models/Wordle.ts
+++ b/src/models/Wordle.ts
@@ -3,6 +3,7 @@ import GameState from "./GameState";
 import Guess from "./Guess";
 import IGameState from "./interfaces/IGameState";
 import IWordle from "./interfaces/IWordle";
+import formatWord from "../services/helpers/FormatWord";
 
 class Wordle implements IWordle {
     guessesLeft(state: IGameState) {
@@ -28,7 +29,8 @@ class Wordle implements IWordle {
         if (state.guesses.length === 0) {
             return false;
         }
-        return state.guesses[state.guesses.length - 1].guess === state.correct;
+        const lastGuess = state.guesses[state.guesses.length - 1].guess;
+        return formatWord(lastGuess) === formatWord(state.correct);
     }
 
     newGame() {

--- a/src/tests/unit_tests/game_logic/wordle.test.ts
+++ b/src/tests/unit_tests/game_logic/wordle.test.ts
@@ -37,6 +37,15 @@ test('sets game state to won if last guess is correct', () => {
     expect(newState.isWon).toBeTruthy();
 });
 
+test('is case insensitive when checking win condition', () => {
+    const CORRECT = 'SWAMP';
+    const state = new GameState(CORRECT, 5);
+    const sut = new Wordle();
+
+    const newState = sut.addGuess(state, CORRECT.toLowerCase());
+    expect(newState.isWon).toBeTruthy();
+});
+
 test('returns correct count for guesses left', () => {
     const CORRECT = "TESTS";
     const state = new GameState(CORRECT, 5);


### PR DESCRIPTION
## Summary
- ensure Wordle checks win condition without case sensitivity
- add regression test for case-insensitive wins

## Testing
- `yarn test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6869689cf4548331b47e7423aaa684ef