### PR TITLE
Add test.each cases for illegal characters

### DIFF
--- a/src/tests/unit_tests/game_logic/word_format.test.js
+++ b/src/tests/unit_tests/game_logic/word_format.test.js
@@ -10,12 +10,14 @@ test('returns word in lowercase', () => {
     expect(formatWord(word)).toBe(expected);
 });
 
-test('throws error if word contains other than alphabetical characters', () => {
-    testThrow("Hello#");
-    // testThrow("He!loo");
-    // testThrow("He$lo");
-    // testThrow("Hell%");
-    // testThrow("'ello");
+test.each([
+    "Hello#",
+    "He!loo",
+    "He$lo",
+    "Hell%",
+    "'ello",
+])('throws error if word contains other than alphabetical characters', (word) => {
+    testThrow(word);
 });
 
 const testThrow = (word) => {


### PR DESCRIPTION
## Summary
- convert commented examples in word_format.test.js into active cases
- use `test.each` to check multiple illegal characters

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686970aac82c833188e61dc47624fc83